### PR TITLE
Create podspec file for iOS CocoaPods users

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,20 @@ $ react-native link
 ```
 
 ### Manual Installation
-#### - iOS
+#### - iOS - Link Manually
 * Add ```.xcodeproj``` file as library to XCode project.
   1. In project navigator, right click Libraries
   2. Select ```Add Files to [PROJECT_NAME]```
   3. Add the ```node_modules/react-native-version-check/ios/RNVersionCheck.xcodeproj``` file
 
 * Add the ```libRNVersionCheck.a``` from the ```RNVersionCheck``` project to your project's Build Phases > Link Binary With Libraries
+
+#### iOS - CocoaPods Package Manager
+* Add to your `Podfile` (assuming it's in `ios/Podfile`):
+  ```ruby
+  pod 'react-native-version-check', :path => '../node_modules/react-native-version-check'
+  ```
+* Reinstall pod with `cd ios && pod install && cd ..`
 
 #### - Android
 

--- a/packages/react-native-version-check-expo/README.md
+++ b/packages/react-native-version-check-expo/README.md
@@ -48,13 +48,20 @@ $ react-native link
 ```
 
 ### Manual Installation
-#### - iOS
+#### - iOS - Link Manually
 * Add ```.xcodeproj``` file as library to XCode project.
   1. In project navigator, right click Libraries
   2. Select ```Add Files to [PROJECT_NAME]```
   3. Add the ```node_modules/react-native-version-check/ios/RNVersionCheck.xcodeproj``` file
 
 * Add the ```libRNVersionCheck.a``` from the ```RNVersionCheck``` project to your project's Build Phases > Link Binary With Libraries
+
+#### iOS - CocoaPods Package Manager
+* Add to your `Podfile` (assuming it's in `ios/Podfile`):
+  ```ruby
+  pod 'react-native-version-check', :path => '../node_modules/react-native-version-check'
+  ```
+* Reinstall pod with `cd ios && pod install && cd ..`
 
 #### - Android
 

--- a/packages/react-native-version-check-expo/react-native-version-check-expo.podspec
+++ b/packages/react-native-version-check-expo/react-native-version-check-expo.podspec
@@ -1,17 +1,22 @@
+require "json"
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
 Pod::Spec.new do |s|
-  s.name         = "react-native-version-check-expo"
-  s.version      = "2.0.1"
-  s.summary      = "Version Check Expo for react-native"
+  s.name         = "react-native-version-check"
+  s.version      = package["version"]
+  s.summary      = package["description"]
 
-  s.homepage     = "https://github.com/kimxogus/react-native-version-check"
+  s.homepage     = package["homepage"]
 
-  s.license      = "MIT"
+  s.license      = package["license"]
   s.authors      = { "kimxogus" => "emailhere" }
   s.platform     = :ios, "7.0"
 
-  s.source       = { :git => "https://github.com/kimxogus/react-native-version-check.git" }
+  s.source       = { :git => package["repository"]["url"] }
 
   s.source_files  = "ios/RNVersionCheck.{h,m}"
+  
+  s.preserve_paths= "package.json", "LICENSE"
 
   s.dependency 'React'
 end

--- a/packages/react-native-version-check-expo/react-native-version-check-expo.podspec
+++ b/packages/react-native-version-check-expo/react-native-version-check-expo.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name         = "react-native-version-check-expo"
+  s.version      = "2.0.1"
+  s.summary      = "Version Check Expo for react-native"
+
+  s.homepage     = "https://github.com/kimxogus/react-native-version-check"
+
+  s.license      = "MIT"
+  s.authors      = { "kimxogus" => "emailhere" }
+  s.platform     = :ios, "7.0"
+
+  s.source       = { :git => "https://github.com/kimxogus/react-native-version-check.git" }
+
+  s.source_files  = "ios/RNVersionCheck.{h,m}"
+
+  s.dependency 'React'
+end

--- a/packages/react-native-version-check/README.md
+++ b/packages/react-native-version-check/README.md
@@ -48,13 +48,20 @@ $ react-native link
 ```
 
 ### Manual Installation
-#### - iOS
+#### - iOS - Link Manually
 * Add ```.xcodeproj``` file as library to XCode project.
   1. In project navigator, right click Libraries
   2. Select ```Add Files to [PROJECT_NAME]```
   3. Add the ```node_modules/react-native-version-check/ios/RNVersionCheck.xcodeproj``` file
 
 * Add the ```libRNVersionCheck.a``` from the ```RNVersionCheck``` project to your project's Build Phases > Link Binary With Libraries
+
+#### iOS - CocoaPods Package Manager
+* Add to your `Podfile` (assuming it's in `ios/Podfile`):
+  ```ruby
+  pod 'react-native-version-check', :path => '../node_modules/react-native-version-check'
+  ```
+* Reinstall pod with `cd ios && pod install && cd ..`
 
 #### - Android
 

--- a/packages/react-native-version-check/react-native-version-check.podspec
+++ b/packages/react-native-version-check/react-native-version-check.podspec
@@ -1,17 +1,22 @@
+require "json"
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
 Pod::Spec.new do |s|
   s.name         = "react-native-version-check"
-  s.version      = "2.0.1"
-  s.summary      = "Version Check for react-native"
+  s.version      = package["version"]
+  s.summary      = package["description"]
 
-  s.homepage     = "https://github.com/kimxogus/react-native-version-check"
+  s.homepage     = package["homepage"]
 
-  s.license      = "MIT"
+  s.license      = package["license"]
   s.authors      = { "kimxogus" => "emailhere" }
   s.platform     = :ios, "7.0"
 
-  s.source       = { :git => "https://github.com/kimxogus/react-native-version-check.git" }
+  s.source       = { :git => package["repository"]["url"] }
 
   s.source_files  = "ios/RNVersionCheck.{h,m}"
+  
+  s.preserve_paths= "package.json", "LICENSE"
 
   s.dependency 'React'
 end

--- a/packages/react-native-version-check/react-native-version-check.podspec
+++ b/packages/react-native-version-check/react-native-version-check.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name         = "react-native-version-check"
+  s.version      = "2.0.1"
+  s.summary      = "Version Check for react-native"
+
+  s.homepage     = "https://github.com/kimxogus/react-native-version-check"
+
+  s.license      = "MIT"
+  s.authors      = { "kimxogus" => "emailhere" }
+  s.platform     = :ios, "7.0"
+
+  s.source       = { :git => "https://github.com/kimxogus/react-native-version-check.git" }
+
+  s.source_files  = "ios/RNVersionCheck.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
This is a simple `.podspec` file that allows you to use:

```rb
pod 'react-native-version-check', :path => '../node_modules/react-native-version-check'
``` 

It might be worth moving the iOS source files into their own folder to allow a nicer `*` source file include.

*Notes*
Feel free to request changes.

Please refer me to `contributing.md` if I've missed one.