### PR TITLE
fix: playStore's market version tokens

### DIFF
--- a/packages/react-native-version-check/src/providers/playStore.js
+++ b/packages/react-native-version-check/src/providers/playStore.js
@@ -4,9 +4,8 @@ import { getVersionInfo } from '../versionInfo';
 import { type IProvider } from './types';
 
 const MARKETVERSION_STARTTOKEN = 'softwareVersion">';
-const MARKETVERSION_ENDTOKEN = '<';
-const MARKETVERSION_STARTTOKEN_NEW =
-  'Current Version</div><div><span class="htlgb">';
+const MARKETVERSION_ENDTOKEN = '</span>';
+const MARKETVERSION_STARTTOKEN_NEW = 'Current Version</div><span class="htlgb"><div><span class="htlgb">';
 
 export type PlayStoreGetVersionOption = {
   packageName?: string,


### PR DESCRIPTION
Due to change in the google play's html, the version from the market was not being taken properly.

Fixes #40 

### Logs:

![screenshot from 2018-04-18 10-21-48](https://user-images.githubusercontent.com/18435853/38917182-9bfdfcf4-42f2-11e8-933c-cce3784fbbb5.png)

### Console output:

![screenshot from 2018-04-18 10-21-25](https://user-images.githubusercontent.com/18435853/38917164-8ba37960-42f2-11e8-96a9-c8d50d5b2c42.png)
