### PR TITLE
Use `Localization.getCurrentDeviceCountryAsync` if its version of exp…

### DIFF
--- a/packages/react-native-version-check-expo/src/ExpoVersionInfo.js
+++ b/packages/react-native-version-check-expo/src/ExpoVersionInfo.js
@@ -8,7 +8,7 @@ if (process.env.RNVC_ENV === 'test') {
   };
 } else {
   const { Platform } = require('react-native');
-  const { Constants, Util } = require('expo');
+  const { Constants, Localization, Util } = require('expo');
 
   const { manifest = {} } = Constants;
   const {
@@ -19,7 +19,7 @@ if (process.env.RNVC_ENV === 'test') {
 
   RNVersionCheck = {
     currentVersion: version,
-    country: Util.getCurrentDeviceCountryAsync(),
+    country: `${Constants.expoVersion < 26 ? Util.getCurrentDeviceCountryAsync : Localization.getCurrentDeviceCountryAsync()}`,
     currentBuildNumber: Platform.select({
       android: versionCode,
       ios: buildNumber,


### PR DESCRIPTION
Hi.I'm using this library to show latest version in expo v26.
Since v26, `Util` is [not available anymore](https://github.com/expo/expo-docs/tree/master/versions/v26.0.0/sdk) and recommended to use `Localization`,so I've added the conditional branch to prevent deprecated error.
