### PR TITLE
use newer country api on expo sdk 31+

### DIFF
--- a/packages/react-native-version-check-expo/src/ExpoVersionInfo.js
+++ b/packages/react-native-version-check-expo/src/ExpoVersionInfo.js
@@ -20,14 +20,18 @@ if (process.env.RNVC_ENV === 'test') {
     android: { versionCode = null, package: androidPackageName = null } = {},
     ios: { bundleIdentifier = null, buildNumber = null } = {},
   } = manifest;
+  let country;
+  if (Constants.expoVersion < 26) {
+    country = Util.getCurrentDeviceCountryAsync();
+  } else if (Constants.expoVersion < 31) {
+    country = Localization.getCurrentDeviceCountryAsync();
+  } else {
+    country = Localization.country;
+  }
 
   RNVersionCheck = {
     currentVersion: version,
-    country: `${
-      Constants.expoVersion < 26
-        ? Util.getCurrentDeviceCountryAsync()
-        : Localization.getCurrentDeviceCountryAsync()
-    }`,
+    country,
     currentBuildNumber: Platform.select({
       android: versionCode,
       ios: buildNumber,


### PR DESCRIPTION
This commit removes a warning that shows up in expo sdk 32 saying that `Localization.getCurrentDeviceCountryAsync()` is deprecated.

Thanks for the useful project!