### PR TITLE
Get app store url without app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ VersionCheck.needUpdate({
     Field | Type | Default
     --- | --- | ---
     appID | _string_ | App ID
-    fetchOptions | _object_ | isomorphic-fetch options (https://github.github.io/fetch/)
     ignoreErrors | _boolean_ | true
 - <a name="getPlayStoreUrl" href="#getPlayStoreUrl">#</a>**`getPlayStoreUrl([option: Object])`** _(Promise<storeUrl: String>)_ - Returns url of Play Store of app.
   - Option

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ VersionCheck.needUpdate({
     Field | Type | Default
     --- | --- | ---
     appID | _string_ | App ID
-    appName | _string_ | App Name
+    fetchOptions | _object_ | isomorphic-fetch options (https://github.github.io/fetch/)
     ignoreErrors | _boolean_ | true
 - <a name="getPlayStoreUrl" href="#getPlayStoreUrl">#</a>**`getPlayStoreUrl([option: Object])`** _(Promise<storeUrl: String>)_ - Returns url of Play Store of app.
   - Option

--- a/packages/react-native-version-check/example/App.js
+++ b/packages/react-native-version-check/example/App.js
@@ -1,5 +1,5 @@
-import React, { Component } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import React, {Component} from 'react';
+import {Linking, StyleSheet, Text, View} from 'react-native';
 import VersionCheck from 'react-native-version-check';
 
 const styles = StyleSheet.create({
@@ -14,6 +14,9 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     margin: 10,
   },
+  linkText: {
+    color: 'blue',
+  },
 });
 
 export default class example extends Component {
@@ -21,11 +24,16 @@ export default class example extends Component {
     currentVersion: null,
     latestVersion: null,
     isNeeded: false,
+    storeUrl: '',
   };
   componentDidMount() {
     VersionCheck.needUpdate({
       latestVersion: '1.0.0',
     }).then(res => this.setState(res));
+
+    VersionCheck.getStoreUrl({appID: '364709193'}).then(res => { //App Store ID for iBooks.
+      this.setState({storeUrl: res})
+    })
   }
   render() {
     return (
@@ -39,6 +47,15 @@ export default class example extends Component {
         <Text style={styles.text}>
           Is update needed?: {String(this.state.isNeeded)}
         </Text>
+        <View>
+          <Text style={styles.text}>
+            Store Url:
+          </Text>
+          <Text style={[styles.text, styles.linkText]}
+                onPress={() => Linking.openURL(this.state.storeUrl)}>
+            {String(this.state.storeUrl)}
+          </Text>
+        </View>
       </View>
     );
   }

--- a/packages/react-native-version-check/src/getStoreUrl.js
+++ b/packages/react-native-version-check/src/getStoreUrl.js
@@ -6,7 +6,6 @@ import { getVersionInfo } from './versionInfo';
 export type GetAppStoreUrlOption = {
   country?: string,
   appID: string,
-  fetchOptions?: any,
   ignoreErrors?: boolean,
 };
 
@@ -31,19 +30,7 @@ export const getAppStoreUrl = async (
 
     const countryCode = option.country ? `${option.country}/` : '';
 
-    return fetch(
-      `https://itunes.apple.com/${countryCode}lookup?id=${option.appID}`,
-      option.fetchOptions
-    )
-      .then(res => res.json())
-      .then(json => {
-        if (json.resultCount) {
-          return `https://itunes.apple.com/${countryCode}app/${
-            json.results[0].trackName
-          }/id${option.appID}`;
-        }
-        return Promise.reject('No info about this app.');
-      });
+    return `https://itunes.apple.com/${countryCode}app/id${option.appID}`;
   } catch (e) {
     if (option.ignoreErrors) {
       console.warn(e); // eslint-disable-line no-console


### PR DESCRIPTION
The `appName` used for `getAppStoreUrl` is an iTunesConnect property and can be changed independently of the application code. Therefore, it would be smarter to avoid the app name in the request. This PR uses the iTunes API to fetch the `trackName`(app name) and put together the app store url that way, removing the previously required `appName` parameter.