### PR TITLE
Change PlayStore crawler hardcoded string to regex

### DIFF
--- a/packages/react-native-version-check/src/providers/__tests__/playStore.js
+++ b/packages/react-native-version-check/src/providers/__tests__/playStore.js
@@ -1,0 +1,103 @@
+import PlayStoreProvider from '../playStore';
+
+const options = {
+  packageName: "com.myapp",
+}
+
+const mockSuccesfulResponse = ( returnBody ) => {
+  global.fetch = jest.fn().mockImplementationOnce(() => {
+    return new Promise((resolve, reject) => {
+      resolve(new Response(returnBody));
+    });
+  });
+};
+
+describe('PlayStoreProvider get version from older Play Store layouts', () => {
+
+  it('get version from older (since ~Apr, 2018) Play Store layout', async () => {
+    mockSuccesfulResponse("\
+      <html>\
+      <div class=\"hAyfc\">\
+        <div class=\"BgcNfc\">\
+            Current Version\
+        </div>\
+        <span class=\"htlgb\">\
+          <div>\
+            <span class=\"htlgb\">0.10.0</span>\
+          </div>\
+        </span>\
+      </div>\
+      </html>\
+    ")
+
+    await PlayStoreProvider.getVersion(options).then(
+      r => expect(r).toBe("0.10.0")
+    );
+  });
+
+  it('get version from ancient (prior to ~Apr, 2018) Play Store layout', async () => {
+    mockSuccesfulResponse("\
+      <html>\
+      <div class=\"hAyfc\">\
+        <div class=\"BgcNfc\">\
+            Current Version\
+        </div>\
+        <span class=\"htlgb\">\
+            <span class=\"softwareVersion\">0.10.0</span>\
+        </span>\
+      </div>\
+      </html>\
+    ")
+
+    await PlayStoreProvider.getVersion(options).then(
+      r => expect(r).toBe("0.10.0")
+    );
+  });
+
+});
+
+describe('PlayStoreProvider get version current (since ~Dec, 2018) Play Store', () => {
+
+  it('with format x.x.x', async () => {
+    mockSuccesfulResponse("\
+      <html>\
+      <div class=\"hAyfc\">\
+        <div class=\"BgcNfc\">\
+            Current Version\
+        </div>\
+        <span class=\"htlgb\">\
+          <div class=\"IQ1z0d\">\
+            <span class=\"htlgb\">0.10.0</span>\
+          </div>\
+        </span>\
+      </div>\
+      </html>\
+    ")
+
+    await PlayStoreProvider.getVersion(options).then(
+      r => expect(r).toBe("0.10.0")
+    );
+  });
+
+  it('with format xxx', async () => {
+    mockSuccesfulResponse("\
+      <html>\
+      <div class=\"hAyfc\">\
+        <div class=\"BgcNfc\">\
+            Current Version\
+        </div>\
+        <span class=\"htlgb\">\
+          <div class=\"IQ1z0d\">\
+            <span class=\"htlgb\">234</span>\
+          </div>\
+        </span>\
+      </div>\
+      </html>\
+    ")
+
+    await PlayStoreProvider.getVersion(options).then(
+      r => expect(r).toBe("234")
+    );
+  });
+});
+

--- a/packages/react-native-version-check/src/providers/playStore.js
+++ b/packages/react-native-version-check/src/providers/playStore.js
@@ -3,11 +3,6 @@ import { getVersionInfo } from '../versionInfo';
 
 import { type IProvider } from './types';
 
-const MARKETVERSION_STARTTOKEN = 'softwareVersion">';
-const MARKETVERSION_ENDTOKEN = '</span>';
-const MARKETVERSION_STARTTOKEN_NEW =
-  'Current Version</div><span class="htlgb"><div class="IQ1z0d"><span class="htlgb">';
-
 export type PlayStoreGetVersionOption = {
   packageName?: string,
   fetchOptions?: any,
@@ -41,28 +36,14 @@ class PlayStoreProvider implements IProvider {
       )
         .then(res => res.text())
         .then(text => {
-          let indexStart = text.indexOf(MARKETVERSION_STARTTOKEN);
-          let startTokenLength = MARKETVERSION_STARTTOKEN.length;
-          let latestVersion = null;
-          if (indexStart === -1) {
-            indexStart = text.indexOf(MARKETVERSION_STARTTOKEN_NEW);
-            startTokenLength = MARKETVERSION_STARTTOKEN_NEW.length;
-            if (indexStart === -1) {
-              return Promise.reject(error(text));
-            }
+          match = text.match(/Current Version.+>([\d.]+)<\/span>/);
+          if(match){
+            latestVersion = match[1].trim();
+            return Promise.resolve(latestVersion);
           }
-
-          text = text.substr(indexStart + startTokenLength);
-
-          const indexEnd = text.indexOf(MARKETVERSION_ENDTOKEN);
-          if (indexEnd === -1) {
+          else{
             return Promise.reject(error(text));
           }
-
-          text = text.substr(0, indexEnd);
-
-          latestVersion = text.trim();
-          return Promise.resolve(latestVersion);
         });
     } catch (e) {
       if (option.ignoreErrors) {


### PR DESCRIPTION
PayStore pages sometimes suffer from small changes (e.g. a div now receives a class).  This should not be enough to break the crawler, so now it is using a regex to find the Current Version.