### PR TITLE
Support dashes in android version number

### DIFF
--- a/packages/react-native-version-check/src/providers/playStore.js
+++ b/packages/react-native-version-check/src/providers/playStore.js
@@ -34,7 +34,7 @@ class PlayStoreProvider implements IProvider {
       return fetch(storeUrl, opt.fetchOptions)
         .then(res => res.text())
         .then(text => {
-          const match = text.match(/Current Version.+?>([\d.]+)<\/span>/);
+          const match = text.match(/Current Version.+?>([\d.-]+)<\/span>/);
           if (match) {
             const latestVersion = match[1].trim();
 


### PR DESCRIPTION
Android versions on Google Play might contain dashes. At the moment `getLatestVersion` will return `.` for these versions. This fix returns the entire version code as expected. 

Example:

![Screenshot 2021-07-14 at 09 00 33](https://user-images.githubusercontent.com/1652607/125577921-15490c46-ab6a-4555-aa11-d86fa4468a26.png)

`getCurrentVersion()` already includes dashes.
