### PR TITLE
fix: play store url

### DIFF
--- a/packages/react-native-version-check/src/providers/playStore.js
+++ b/packages/react-native-version-check/src/providers/playStore.js
@@ -29,7 +29,7 @@ class PlayStoreProvider implements IProvider {
         opt.packageName = getVersionInfo().getPackageName();
       }
 
-      const storeUrl = `https://play.google.com/store/apps/details?id=${opt.packageName}&hl=en`;
+      const storeUrl = `https://play.google.com/store/apps/details?id=${opt.packageName}&hl=en&gl=US`;
 
       return fetch(storeUrl, opt.fetchOptions)
         .then(res => res.text())


### PR DESCRIPTION
Play store HTML was updated
Temporarily, I attached the URL parameter that fetches the previous HTML.
We have to figure out another way to get the version.

## Current
![image](https://user-images.githubusercontent.com/26326015/148923799-9f8d6aee-36ac-4a33-8188-7e3ea2406262.png)

## Previous
![image](https://user-images.githubusercontent.com/26326015/148923767-30aa2c98-5c41-4ad3-9436-e14bc4c454b2.png)
