### PR TITLE
Fix build with expo SDK 44+

### DIFF
--- a/packages/react-native-version-check/ios/RNVersionCheck.h
+++ b/packages/react-native-version-check/ios/RNVersionCheck.h
@@ -1,5 +1,5 @@
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RNVersionCheck : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
Updated way of importing RCTBridgeModule. The old one would create duplicated imports error.