### PR TITLE
Update react-native-version-check.podspec

### DIFF
--- a/packages/react-native-version-check/react-native-version-check.podspec
+++ b/packages/react-native-version-check/react-native-version-check.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
 
   s.preserve_paths= "package.json", "LICENSE"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
Fix error : Undefined symbols _RCTRegisterModule when building on iOS.