### PR TITLE
added support version using hyphen

### DIFF
--- a/packages/react-native-version-check/src/providers/playStore.js
+++ b/packages/react-native-version-check/src/providers/playStore.js
@@ -46,7 +46,7 @@ class PlayStoreProvider implements IProvider {
             return Promise.resolve({ version: latestVersion, storeUrl });
           }
 
-          const matchNewLayout = text.match(/\[\[\["([\d.]+?)"\]\]/);
+          const matchNewLayout = text.match(/\[\[\["([\d-.]+?)"\]\]/);
           if (matchNewLayout) {
             const latestVersion = matchNewLayout[1].trim();
 


### PR DESCRIPTION
Issue:
if your version has `-`,the function that checks the match doesn't find it and returns `undefined` Ex : `2.1.1-1`

Solution:
Allow the hyphen in the expression.