### PR TITLE
Use latest expo modules and remove deprecated manifest access

### DIFF
--- a/packages/react-native-version-check-expo/package.json
+++ b/packages/react-native-version-check-expo/package.json
@@ -22,15 +22,15 @@
     "Mohamad Arif Raja <rfraja2943@gmail.com>"
   ],
   "peerDependencies": {
-    "expo": ">=26"
+    "expo": ">=50"
   },
   "dependencies": {
-    "expo-constants": "^14.0.2",
-    "expo-localization": "^14.0.0",
+    "expo-constants": "^16.0.1",
+    "expo-localization": "^15.0.3",
     "react-native-version-check": "^3.4.7"
   },
   "devDependencies": {
-    "expo": "^33.0.0",
+    "expo": "^51.0.2",
     "react-native": "https://github.com/expo/react-native/archive/sdk-33.0.0.tar.gz"
   }
 }

--- a/packages/react-native-version-check-expo/src/ExpoVersionInfo.js
+++ b/packages/react-native-version-check-expo/src/ExpoVersionInfo.js
@@ -11,8 +11,8 @@ if (process.env.RNVC_ENV === 'test') {
     currentVersion: '0.0.1',
   };
 } else {
-  const manifest = Constants.manifest
-    ? Constants.manifest
+  const manifest = Constants.expoConfig
+    ? Constants.expoConfig
     : Constants.manifest2.extra.expoClient;
   const {
     version = null,


### PR DESCRIPTION
Unfortunately, I could not test it since packing the package failed when specifying this branch as package version. 